### PR TITLE
feat: implement persistent user registration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,6 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     implementation(libs.material)
-    implementation("androidx.fragment:fragment-ktx:1.8.5")
-
+    implementation(libs.androidx.fragment.ktx)
+    implementation(libs.gson)
 }

--- a/app/src/androidTest/java/com/example/mobileapplications_3rdclass/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/mobileapplications_3rdclass/ExampleInstrumentedTest.kt
@@ -1,24 +1,77 @@
 package com.example.mobileapplications_3rdclass
 
-import androidx.test.platform.app.InstrumentationRegistry
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import org.junit.Assert.*
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
-import org.junit.Assert.*
-
-/**
- * Instrumented test, which will execute on an Android device.
- *
- * See [testing documentation](http://d.android.com/tools/testing).
- */
 @RunWith(AndroidJUnit4::class)
-class ExampleInstrumentedTest {
+class CredentialsManagerTest {
+
+    private lateinit var credentialsManager: CredentialsManager
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext<Context>()
+        credentialsManager = CredentialsManager(context)
+    }
+
     @Test
-    fun useAppContext() {
-        // Context of the app under test.
-        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.example.mobileapplications_3rdclass", appContext.packageName)
+    fun testIsEmailValid() {
+        assertTrue(credentialsManager.isEmailValid("test@example.com"))
+        assertFalse(credentialsManager.isEmailValid("invalid_email"))
+        assertFalse(credentialsManager.isEmailValid(""))
+    }
+
+    @Test
+    fun testIsPasswordValid() {
+        assertTrue(credentialsManager.isPasswordValid("password123"))
+        assertFalse(credentialsManager.isPasswordValid(""))
+    }
+
+    @Test
+    fun testRegister_NewAccount_Success() {
+        assertTrue(credentialsManager.register("test@example.com", "password123"))
+        assertTrue(credentialsManager.isLoginValid("test@example.com", "password123"))
+    }
+
+    @Test
+    fun testRegister_ExistingAccount_Failure() {
+        credentialsManager.register("test@example.com", "password123")
+        assertFalse(credentialsManager.register("test@example.com", "anotherPassword"))
+        assertFalse(credentialsManager.register("TEST@example.com", "anotherPassword"))
+    }
+
+    @Test
+    fun testRegister_CaseInsensitive_Failure() {
+        credentialsManager.register("test@example.com", "password123")
+        assertFalse(credentialsManager.register("TEST@EXAMPLE.COM", "anotherPassword"))
+    }
+
+    @Test
+    fun testIsLoginValid_ValidCredentials_Success() {
+        credentialsManager.register("test@example.com", "password123")
+        assertTrue(credentialsManager.isLoginValid("test@example.com", "password123"))
+    }
+
+    @Test
+    fun testIsLoginValid_InvalidPassword_Failure() {
+        credentialsManager.register("test@example.com", "password123")
+        assertFalse(credentialsManager.isLoginValid("test@example.com", "wrongPassword"))
+    }
+
+    @Test
+    fun testIsLoginValid_InvalidEmail_Failure() {
+        assertFalse(credentialsManager.isLoginValid("nonexistent@example.com", "password123"))
+    }
+
+    @Test
+    fun testIsLoginValid_CaseInsensitive_Success() {
+        credentialsManager.register("test@example.com", "password123")
+        assertTrue(credentialsManager.isLoginValid("TEST@EXAMPLE.COM", "password123"))
     }
 }

--- a/app/src/androidTest/java/com/example/mobileapplications_3rdclass/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/mobileapplications_3rdclass/ExampleInstrumentedTest.kt
@@ -18,6 +18,8 @@ class CredentialsManagerTest {
     fun setUp() {
         context = ApplicationProvider.getApplicationContext<Context>()
         credentialsManager = CredentialsManager(context)
+        val sharedPreferences = context.getSharedPreferences("credentials", Context.MODE_PRIVATE)
+        sharedPreferences.edit().clear().commit()
     }
 
     @Test
@@ -73,5 +75,17 @@ class CredentialsManagerTest {
     fun testIsLoginValid_CaseInsensitive_Success() {
         credentialsManager.register("test@example.com", "password123")
         assertTrue(credentialsManager.isLoginValid("TEST@EXAMPLE.COM", "password123"))
+    }
+
+    @Test
+    fun login_with_test_at_te_st_and_1234_succeeds() {
+        credentialsManager.register("test@te.st", "1234")
+        assertTrue("Login should succeed with test@te.st and 1234", credentialsManager.isLoginValid("test@te.st", "1234"))
+    }
+
+    @Test
+    fun login_with_test_at_te_st_and_incorrect_password_fails() {
+        credentialsManager.register("test@te.st", "1234")
+        assertFalse("Login should fail with test@te.st and incorrect password", credentialsManager.isLoginValid("test@te.st", "wrong"))
     }
 }

--- a/app/src/main/java/com/example/mobileapplications_3rdclass/CredentialsManager.kt
+++ b/app/src/main/java/com/example/mobileapplications_3rdclass/CredentialsManager.kt
@@ -1,6 +1,15 @@
 package com.example.mobileapplications_3rdclass
 
-class CredentialsManager {
+import android.content.Context
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+class CredentialsManager(private val context: Context) {
+
+    private val sharedPreferences = context.getSharedPreferences("credentials", Context.MODE_PRIVATE)
+    private val gson = Gson()
+    private val accounts: MutableMap<String, String> = loadAccounts()
+
     fun isEmailValid(email: String): Boolean {
         val emailPattern = "[a-zA-Z0-9._-]+@[a-z]+\\.+[a-z]+"
         return email.isNotEmpty() && email.matches(emailPattern.toRegex())
@@ -8,5 +17,49 @@ class CredentialsManager {
 
     fun isPasswordValid(password: String): Boolean {
         return password.isNotEmpty()
+    }
+
+    /**
+     * Registers a new account with the given email and password.
+     *
+     * @param email The email address to register.
+     * @param password The password for the new account.
+     * @return True if the registration was successful, false if the email is already registered.
+     */
+    fun register(email: String, password: String): Boolean {
+        val lowerCaseEmail = email.lowercase()
+        if (accounts.containsKey(lowerCaseEmail)) {
+            return false // Email already exists
+        }
+        accounts[lowerCaseEmail] = password
+        saveAccounts()
+        return true // Registration successful
+    }
+
+    /**
+     * Checks if an account with the given email and password exists.
+     *
+     * @param email The email address to check.
+     * @param password The password to check.
+     * @return True if the credentials are valid, false otherwise.
+     */
+    fun isLoginValid(email: String, password: String): Boolean {
+        val lowerCaseEmail = email.lowercase()
+        return accounts[lowerCaseEmail] == password
+    }
+
+    private fun loadAccounts(): MutableMap<String, String> {
+        val accountsJson = sharedPreferences.getString("accounts", null)
+        return if (accountsJson != null) {
+            val type = object : TypeToken<MutableMap<String, String>>() {}.type
+            gson.fromJson(accountsJson, type)
+        } else {
+            mutableMapOf()
+        }
+    }
+
+    private fun saveAccounts() {
+        val accountsJson = gson.toJson(accounts)
+        sharedPreferences.edit().putString("accounts", accountsJson).apply()
     }
 }

--- a/app/src/main/java/com/example/mobileapplications_3rdclass/CredentialsManager.kt
+++ b/app/src/main/java/com/example/mobileapplications_3rdclass/CredentialsManager.kt
@@ -7,10 +7,12 @@ import com.google.gson.reflect.TypeToken
 class CredentialsManager {
 
     private val accounts: MutableMap<String, String> = mutableMapOf()
+    private var appContext: Context? = null
 
     constructor()
 
     constructor(context: Context) {
+        this.appContext = context.applicationContext
         val sharedPreferences = context.getSharedPreferences("credentials", Context.MODE_PRIVATE)
         val gson = Gson()
         val accountsJson = sharedPreferences.getString("accounts", null)
@@ -46,9 +48,17 @@ class CredentialsManager {
             return false // Email already exists
         }
         accounts[lowerCaseEmail] = password
+        saveAccountsToSharedPreferences()
         return true // Registration successful
     }
 
+    private fun saveAccountsToSharedPreferences() {
+        val context = appContext ?: return
+        val sharedPreferences = context.getSharedPreferences("credentials", Context.MODE_PRIVATE)
+        val gson = Gson()
+        val accountsJson = gson.toJson(accounts)
+        sharedPreferences.edit().putString("accounts", accountsJson).apply()
+    }
     /**
      * Checks if an account with the given email and password exists.
      *

--- a/app/src/main/java/com/example/mobileapplications_3rdclass/CredentialsManager.kt
+++ b/app/src/main/java/com/example/mobileapplications_3rdclass/CredentialsManager.kt
@@ -4,11 +4,25 @@ import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
-class CredentialsManager(private val context: Context) {
+class CredentialsManager {
 
-    private val sharedPreferences = context.getSharedPreferences("credentials", Context.MODE_PRIVATE)
-    private val gson = Gson()
-    private val accounts: MutableMap<String, String> = loadAccounts()
+    private val accounts: MutableMap<String, String> = mutableMapOf()
+
+    constructor()
+
+    constructor(context: Context) {
+        val sharedPreferences = context.getSharedPreferences("credentials", Context.MODE_PRIVATE)
+        val gson = Gson()
+        val accountsJson = sharedPreferences.getString("accounts", null)
+        accounts.putAll(
+            if (accountsJson != null) {
+                val type = object : TypeToken<MutableMap<String, String>>() {}.type
+                gson.fromJson(accountsJson, type)
+            } else {
+                mutableMapOf()
+            }
+        )
+    }
 
     fun isEmailValid(email: String): Boolean {
         val emailPattern = "[a-zA-Z0-9._-]+@[a-z]+\\.+[a-z]+"
@@ -32,7 +46,6 @@ class CredentialsManager(private val context: Context) {
             return false // Email already exists
         }
         accounts[lowerCaseEmail] = password
-        saveAccounts()
         return true // Registration successful
     }
 
@@ -46,20 +59,5 @@ class CredentialsManager(private val context: Context) {
     fun isLoginValid(email: String, password: String): Boolean {
         val lowerCaseEmail = email.lowercase()
         return accounts[lowerCaseEmail] == password
-    }
-
-    private fun loadAccounts(): MutableMap<String, String> {
-        val accountsJson = sharedPreferences.getString("accounts", null)
-        return if (accountsJson != null) {
-            val type = object : TypeToken<MutableMap<String, String>>() {}.type
-            gson.fromJson(accountsJson, type)
-        } else {
-            mutableMapOf()
-        }
-    }
-
-    private fun saveAccounts() {
-        val accountsJson = gson.toJson(accounts)
-        sharedPreferences.edit().putString("accounts", accountsJson).apply()
     }
 }

--- a/app/src/main/java/com/example/mobileapplications_3rdclass/LoginActivity.kt
+++ b/app/src/main/java/com/example/mobileapplications_3rdclass/LoginActivity.kt
@@ -28,12 +28,14 @@ class LoginActivity : AppCompatActivity() {
     private val nextButton: MaterialButton
         get() = findViewById(R.id.next_button)
 
-    private val credentialsManager = CredentialsManager()
+    private lateinit var credentialsManager: CredentialsManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContentView(R.layout.activity_sign_in)
+
+        credentialsManager = CredentialsManager(applicationContext)
 
         // Handle Window Insets if necessary
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.sign_in_layout)) { v, insets ->
@@ -68,11 +70,11 @@ class LoginActivity : AppCompatActivity() {
             if (!isPasswordValid) {
                 passwordInputLayout.error = "Password cannot be empty"
             }
-            
+
 
             if (isEmailValid && isPasswordValid) {
                 // Check if credentials match hardcoded ones
-                if (email == "test@te.st" && password == "1234") {
+                if (credentialsManager.isLoginValid(email, password)) {
                     val intent = Intent(this, MainActivity::class.java)
                     startActivity(intent)
                     finish()

--- a/app/src/main/java/com/example/mobileapplications_3rdclass/RegisterActivity.kt
+++ b/app/src/main/java/com/example/mobileapplications_3rdclass/RegisterActivity.kt
@@ -38,12 +38,14 @@ class RegisterActivity : AppCompatActivity() {
     private val nextButton: MaterialButton
         get() = findViewById(R.id.next_button)
 
-    private val credentialsManager = CredentialsManager()
+    private lateinit var credentialsManager: CredentialsManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContentView(R.layout.activity_main)
+
+        credentialsManager = CredentialsManager(applicationContext)
 
         // Handle Window Insets if necessary
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.create_account_layout)) { v, insets ->
@@ -96,8 +98,17 @@ class RegisterActivity : AppCompatActivity() {
             }
 
             if (isFullNameValid && isEmailValid && isPhoneNumberValid && isPasswordValid && isTermsChecked) {
-                Toast.makeText(this, "Registration Successful", Toast.LENGTH_SHORT).show()
-                // Proceed to next step or activity (in theory :b)
+                val registrationSuccessful = credentialsManager.register(email, password)
+
+                if (registrationSuccessful) {
+                    Toast.makeText(this, "Registration Successful", Toast.LENGTH_SHORT).show()
+                    // Go back to LoginActivity
+                    val intent = Intent(this, LoginActivity::class.java)
+                    startActivity(intent)
+                    finish()
+                } else {
+                    emailInputLayout.error = "Email already registered"
+                }
             }
         }
     }

--- a/app/src/test/java/com/example/mobileapplications_3rdclass/CredentialsManagerTest.kt
+++ b/app/src/test/java/com/example/mobileapplications_3rdclass/CredentialsManagerTest.kt
@@ -1,12 +1,17 @@
 package com.example.mobileapplications_3rdclass
 
 import org.junit.Assert.*
+import org.junit.Before
 import org.junit.Test
 
 class CredentialsManagerTest {
 
-    private val credentialsManager = CredentialsManager()
+    private lateinit var credentialsManager: CredentialsManager
 
+    @Before
+    fun setUp() {
+        credentialsManager = CredentialsManager()
+    }
     // Email Validation Tests
 
     @Test
@@ -44,5 +49,17 @@ class CredentialsManagerTest {
         val password = "ExamplePassword123"
         val result = credentialsManager.isPasswordValid(password)
         assertTrue("Non-empty password should be valid", result)
+    }
+
+    @Test
+    fun `login with test@te,st and 1234 succeeds`() {
+        credentialsManager.register("test@te.st", "1234")
+        assertTrue("Login should succeed with test@te.st and 1234", credentialsManager.isLoginValid("test@te.st", "1234"))
+    }
+
+    @Test
+    fun `login with test@te,st and incorrect password fails`() {
+        credentialsManager.register("test@te.st", "1234")
+        assertFalse("Login should fail with test@te.st and incorrect password", credentialsManager.isLoginValid("test@te.st", "wrong"))
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 agp = "8.7.3"
+fragmentKtx = "1.8.5"
+gson = "2.10.1"
 kotlin = "1.9.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"
@@ -12,6 +14,8 @@ constraintlayout = "2.1.4"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragmentKtx" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
## Description
- Added a `register` method to `CredentialsManager` to handle new user registration.
- Implemented account storage using SharedPreferences with Gson for serialization.
- Added unit tests for the new registration functionality in `CredentialsManagerTest`.

## How to Test
- Run the unit tests for CredentialsManager.
- Register a new user via the registration screen:
- Use a new email and verify successful navigation to the login screen.
- Try to register with an existing email (case-insensitive) and ensure an error is displayed.
- Log in using the newly created account.